### PR TITLE
Fix bug

### DIFF
--- a/resgen/utils.py
+++ b/resgen/utils.py
@@ -1,3 +1,4 @@
+import os.path as op
 import sys
 
 _track_default_position = {


### PR DESCRIPTION
```
line 141, in infer_filetype
    _, ext = op.splitext(filename)
             ^^
NameError: name 'op' is not defined
```