### PR TITLE
Add finch container runtime support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.15.0
 
 - Add support for [finch](https://github.com/runfinch/finch) as an alternative container runtime in `resgen manage`. The runtime is auto-detected from PATH (docker preferred for backwards compatibility) or can be set explicitly via the `RESGEN_CONTAINER_RUNTIME` environment variable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add support for [finch](https://github.com/runfinch/finch) as an alternative container runtime in `resgen manage`. The runtime is auto-detected from PATH (docker preferred for backwards compatibility) or can be set explicitly via the `RESGEN_CONTAINER_RUNTIME` environment variable
+
 ## v0.14.0
 
 - Save credentials to `<directory>/.resgen/credentials` after the first login prompt for `resgen manage view` and `resgen manage pileup`, so subsequent runs in the same directory don't re-prompt

--- a/resgen/manage.py
+++ b/resgen/manage.py
@@ -22,11 +22,30 @@ from resgen.utils import (
     infer_datatype,
 )
 
+import shutil
 import sys
 
 from slugid import nice
 
 logger = logging.getLogger(__name__)
+
+
+def get_container_runtime():
+    """Get the container runtime to use (docker or finch).
+
+    Checks the RESGEN_CONTAINER_RUNTIME environment variable first.
+    If not set, auto-detects by checking which binaries are in PATH,
+    preferring docker for backwards compatibility.
+    """
+    runtime = os.environ.get("RESGEN_CONTAINER_RUNTIME")
+    if runtime:
+        return runtime
+
+    for candidate in ("docker", "finch"):
+        if shutil.which(candidate):
+            return candidate
+
+    return "docker"  # fallback default
 
 START_TEMPLATE = """
 services:
@@ -184,7 +203,7 @@ def _start(
             try:
                 result = subprocess.run(
                     [
-                        "docker",
+                        get_container_runtime(),
                         "exec",
                         current_container["id"],
                         "test",
@@ -282,7 +301,7 @@ def _start(
 
         f.write(compose_text)
 
-    cmd = ["docker", "compose"]
+    cmd = [get_container_runtime(), "compose"]
     cmd += ["--project-directory", "."]
     cmd += ["-f", compose_file, "up"]
     if not foreground:
@@ -336,7 +355,7 @@ def stop(directory):
     """Stop a running instance."""
     compose_file = get_compose_file(directory)
 
-    run(["docker", "compose", "-f", compose_file, "down"])
+    run([get_container_runtime(), "compose", "-f", compose_file, "down"])
 
 
 @manage.command()
@@ -375,10 +394,11 @@ def shell(directory, style):
     """
     directory_hash = hashlib.md5(abspath(directory).encode()).hexdigest()[:8]
 
+    runtime = get_container_runtime()
     if style == "run":
         run(
             [
-                "docker",
+                runtime,
                 "run",
                 "-v",
                 f"{directory}/.resgen/data/:/data",
@@ -388,7 +408,7 @@ def shell(directory, style):
             ]
         )
     else:
-        run(["docker", "exec", "-it", f"rgc-{directory_hash}", "bash"])
+        run([runtime, "exec", "-it", f"rgc-{directory_hash}", "bash"])
 
 
 def _create_user(directory, username, password):
@@ -399,7 +419,7 @@ def _create_user(directory, username, password):
 
     run(
         [
-            "docker",
+            get_container_runtime(),
             "compose",
             "--project-directory",
             directory,
@@ -435,7 +455,7 @@ def create_superuser(directory):
 
     run(
         [
-            "docker",
+            get_container_runtime(),
             "compose",
             "--project-directory",
             directory,
@@ -533,9 +553,10 @@ def _get_running_containers(image=DEFAULT_IMAGE):
     import json
 
     try:
+        runtime = get_container_runtime()
         result = subprocess.run(
             [
-                "docker",
+                runtime,
                 "ps",
                 "--filter",
                 "name=rgc-",
@@ -555,7 +576,7 @@ def _get_running_containers(image=DEFAULT_IMAGE):
             if line:
                 container = json.loads(line)
                 inspect_result = subprocess.run(
-                    ["docker", "inspect", container["ID"]],
+                    [runtime, "inspect", container["ID"]],
                     capture_output=True,
                     text=True,
                     check=True,
@@ -644,7 +665,7 @@ def update(image):
 
     Does the same thing as the "pull" command below
     """
-    run(["docker", "pull", image])
+    run([get_container_runtime(), "pull", image])
     logger.info(f"Updated image: {image}")
 
 
@@ -655,7 +676,7 @@ def pull(image):
 
     Alias of "update"
     """
-    run(["docker", "pull", image])
+    run([get_container_runtime(), "pull", image])
     logger.info(f"Updated image: {image}")
 
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -3,10 +3,107 @@ import tempfile
 from unittest.mock import MagicMock, patch, call
 import pytest
 
-from resgen.manage import _sync_datasets, can_sync_datasets
+from resgen.manage import _sync_datasets, can_sync_datasets, get_container_runtime
 from resgen.license import LicenseInfo, LicenseError
 from resgen.exceptions import ResgenError
 from resgen import UnknownConnectionException
+
+
+class TestGetContainerRuntime:
+    """Test suite for the get_container_runtime function."""
+
+    def test_env_var_takes_precedence(self):
+        """Test that RESGEN_CONTAINER_RUNTIME env var overrides auto-detection."""
+        with patch.dict(os.environ, {"RESGEN_CONTAINER_RUNTIME": "finch"}):
+            with patch("shutil.which", return_value="/usr/local/bin/docker"):
+                assert get_container_runtime() == "finch"
+
+    def test_env_var_docker(self):
+        """Test that RESGEN_CONTAINER_RUNTIME can explicitly select docker."""
+        with patch.dict(os.environ, {"RESGEN_CONTAINER_RUNTIME": "docker"}):
+            with patch("shutil.which", return_value=None):
+                assert get_container_runtime() == "docker"
+
+    def test_autodetect_docker_when_only_docker_present(self):
+        """Test that docker is selected when only docker is in PATH."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("RESGEN_CONTAINER_RUNTIME", None)
+            with patch("shutil.which", side_effect=lambda x: "/usr/bin/docker" if x == "docker" else None):
+                assert get_container_runtime() == "docker"
+
+    def test_autodetect_finch_when_only_finch_present(self):
+        """Test that finch is selected when only finch is in PATH."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("RESGEN_CONTAINER_RUNTIME", None)
+            with patch("shutil.which", side_effect=lambda x: "/usr/local/bin/finch" if x == "finch" else None):
+                assert get_container_runtime() == "finch"
+
+    def test_autodetect_prefers_docker_when_both_present(self):
+        """Test that docker is preferred over finch when both are available."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("RESGEN_CONTAINER_RUNTIME", None)
+            with patch("shutil.which", return_value="/usr/local/bin/runtime"):
+                assert get_container_runtime() == "docker"
+
+    def test_fallback_to_docker_when_neither_present(self):
+        """Test that docker is returned as fallback when neither runtime is in PATH."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("RESGEN_CONTAINER_RUNTIME", None)
+            with patch("shutil.which", return_value=None):
+                assert get_container_runtime() == "docker"
+
+
+class TestManageCommandsUseRuntime:
+    """Test that manage commands delegate to the configured container runtime."""
+
+    @patch("resgen.manage.get_container_runtime", return_value="finch")
+    @patch("resgen.manage.run")
+    def test_stop_uses_runtime(self, mock_run, mock_runtime):
+        """Test that stop passes the detected runtime to compose down."""
+        from resgen.manage import stop
+        from click.testing import CliRunner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compose_dir = os.path.join(tmpdir, ".resgen", "config")
+            os.makedirs(compose_dir)
+            compose_file = os.path.join(compose_dir, "stack.yml")
+            with open(compose_file, "w") as f:
+                f.write("")
+
+            result = CliRunner().invoke(stop, [tmpdir])
+
+        assert mock_runtime.called
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "finch"
+        assert "compose" in cmd
+
+    @patch("resgen.manage.get_container_runtime", return_value="finch")
+    @patch("resgen.manage.run")
+    def test_pull_uses_runtime(self, mock_run, mock_runtime):
+        """Test that pull passes the detected runtime to the pull subcommand."""
+        from resgen.manage import pull
+        from click.testing import CliRunner
+
+        CliRunner().invoke(pull, [])
+
+        assert mock_runtime.called
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "finch"
+        assert cmd[1] == "pull"
+
+    @patch("resgen.manage.get_container_runtime", return_value="finch")
+    @patch("resgen.manage.run")
+    def test_update_uses_runtime(self, mock_run, mock_runtime):
+        """Test that update passes the detected runtime to the pull subcommand."""
+        from resgen.manage import update
+        from click.testing import CliRunner
+
+        CliRunner().invoke(update, [])
+
+        assert mock_runtime.called
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "finch"
+        assert cmd[1] == "pull"
 
 
 class TestSyncDatasets:


### PR DESCRIPTION
## Summary

- Adds `get_container_runtime()` function that selects the container runtime (docker or finch) by checking the `RESGEN_CONTAINER_RUNTIME` environment variable, then auto-detecting from PATH (docker preferred for backwards compatibility)
- Replaces all hardcoded `"docker"` CLI invocations in `manage.py` with `get_container_runtime()` across `start`, `stop`, `shell`, `create_user`, `create_superuser`, `update`, `pull`, and `_get_running_containers`

## Test plan

- [ ] Verify existing docker-based workflows still work (no behaviour change when docker is the only runtime installed)
- [ ] Test with finch installed: `resgen manage start`, `stop`, `logs`, `shell`, `update` all use `finch` commands
- [ ] Test explicit override: `RESGEN_CONTAINER_RUNTIME=finch resgen manage start .` routes to finch even when docker is also present
- [ ] Test explicit override: `RESGEN_CONTAINER_RUNTIME=docker resgen manage start .` routes to docker even when finch is also present